### PR TITLE
Fix small typo

### DIFF
--- a/docs/week8/articles/petrinets.md
+++ b/docs/week8/articles/petrinets.md
@@ -58,7 +58,7 @@ $$
 
 In Worten: Die Transition ist aktiviert wenn für alle Input Stellen einer Transition mindestens soviele Markierungen vorhanden sind, wie durch die entsprechende Gewichten auf der Flussreaktion vorgegeben.
 In unserem einfachen Beispiel ist Transition $$t_1$$ also aktiviert und kann schalten.
-![petri-netz] (../../slides/images/petri-net-simple-initial.png)
+![petri-netz](../../slides/images/petri-net-simple-initial.png)
                   
 Nun schauen wir uns die Dynamik noch an einem etwas komplexeren Beispiel an:
 


### PR DESCRIPTION
There was a space missing in a link so it only showed the link of the image instead of the actual image. I've fixed that.