### PR TITLE
Correct expired UML article link

### DIFF
--- a/docs/week5/guide.md
+++ b/docs/week5/guide.md
@@ -44,7 +44,7 @@ Als Vorbereitung für die Vorlesungsstunde in dieser Woche bearbeiten Sie bitte 
 * Schritt 3: Schauen Sie sich das Video zu den "SOLID Prinzipien" an ([Video](https://tube.switch.ch/videos/cbc347a9), [Slides](./slides/oo-solid.html))
 * Schritt 4: Lesen Sie den Artikel "Das Gesetz von Demeter" ([Artikel](http://prinzipien-der-softwaretechnik.blogspot.com/2013/06/das-gesetz-von-demeter.html))
 * Schritt 5: Schauen Sie sich das Video "UML Einführung" an. ([Video](https://tube.switch.ch/videos/b43beebb), [Slides](./slides/uml-static.html))
-* Schritt 6: Lesen Sie diesen Artikel zu UML Klassendiagrammen ([Artikel](https://www.ibm.com/developerworks/rational/library/content/RationalEdge/sep04/bell/))
+* Schritt 6: Lesen Sie diesen Artikel zu UML Klassendiagrammen ([Artikel](https://developer.ibm.com/articles/the-class-diagram/))
 * Schritt 7: Bearbeiten Sie den Test. ([Adam](https://adam.unibas.ch/goto_adam_tst_1271688.html)).
 
 *Achtung: Der Test muss spätestens bis Mittwoch 20. Oktober, 08:00 bearbeitet sein.*


### PR DESCRIPTION
Hey Marcel, one article link on the preparation site for the upcoming week didn't work anymore; so I changed it to what might be the article we are supposed to read. Please check whether it's the right one, thank you!

Expired [IBM UML article](https://www.ibm.com/developerworks/rational/library/content/RationalEdge/sep04/bell/)

Updated [IBM UML article](https://developer.ibm.com/articles/the-class-diagram/)
