### PR TITLE
Correction deadlines for "Testplan erstellen" milestone

### DIFF
--- a/docs/project/week10/exercises.md
+++ b/docs/project/week10/exercises.md
@@ -31,4 +31,4 @@ Finden Sie heraus, wie hoch die Testabdeckung durch Unittests für Jabref insges
 
 Speichern Sie die Dokumente im docs Ordner von ihrem Repository ab.
 
-Die Abgabe erfolgt pro Gruppe, mittels Pull Request. Geben Sie Ihren Betreuer (also ```marcelluethi```, ```emugdan```, ```colinhex``` oder ```guenesaydin```) als Reviewer an. Abgabetermin ist Sonntag, 22. November, 23:55. Die Besprechung mit den Betreuern findet am 25. November statt. Die Abgabe der überarbeiteten und finalen Version erfolgt dann bis spätestens 1. Dezember, 23.55.
+Die Abgabe erfolgt pro Gruppe, mittels Pull Request. Geben Sie Ihren Betreuer (also ```marcelluethi```, ```emugdan```, ```colinhex``` oder ```guenesaydin```) als Reviewer an. Abgabetermin ist Sonntag, 28. November, 23:55. Die Besprechung mit den Betreuern findet am 1. Dezember statt. Die Abgabe der überarbeiteten und finalen Version erfolgt dann bis spätestens 8. Dezember, 23.55.

--- a/docs/week5/guide.md
+++ b/docs/week5/guide.md
@@ -44,7 +44,7 @@ Als Vorbereitung für die Vorlesungsstunde in dieser Woche bearbeiten Sie bitte 
 * Schritt 3: Schauen Sie sich das Video zu den "SOLID Prinzipien" an ([Video](https://tube.switch.ch/videos/cbc347a9), [Slides](./slides/oo-solid.html))
 * Schritt 4: Lesen Sie den Artikel "Das Gesetz von Demeter" ([Artikel](http://prinzipien-der-softwaretechnik.blogspot.com/2013/06/das-gesetz-von-demeter.html))
 * Schritt 5: Schauen Sie sich das Video "UML Einführung" an. ([Video](https://tube.switch.ch/videos/b43beebb), [Slides](./slides/uml-static.html))
-* Schritt 6: Lesen Sie diesen Artikel zu UML Klassendiagrammen ([Artikel](https://www.ibm.com/developerworks/rational/library/content/RationalEdge/sep04/bell/))
+* Schritt 6: Lesen Sie diesen Artikel zu UML Klassendiagrammen ([Artikel](https://developer.ibm.com/articles/the-class-diagram/))
 * Schritt 7: Bearbeiten Sie den Test. ([Adam](https://adam.unibas.ch/goto_adam_tst_1271688.html)).
 
 *Achtung: Der Test muss spätestens bis Mittwoch 20. Oktober, 08:00 bearbeitet sein.*


### PR DESCRIPTION
Die Deadlines für die Übungen von dieser und nächster Woche scheinen etwas verfrüht zu sein. Ich habe mich bei der Korrektur an den Daten aus der [Projektübersicht](https://unibas-marcelluethi.github.io/software-engineering/project/project-summary.html) und der Tatsache, dass auf der [Übungsseite](https://unibas-marcelluethi.github.io/software-engineering/project/week10/exercises) der Stoff von Woche 10 auch inkludiert ist, orientiert.