### PR TITLE
Add Home Page Link to Header 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,3 +34,5 @@ end
 gem "wdm", "~> 0.1.1", :install_if => Gem.win_platform?
 
 gem "jekyll", "~> 3.9"
+
+gem "webrick", "~> 1.8"

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -14,7 +14,7 @@
   <body>
 
     <!-- HEADER -->
-    <a href="http://127.0.0.1:4000" id="home_link">
+    <a href="https://rahelv.github.io/software-engineering/" id="home_link">
         <div id="header_wrap" class="outer">
             <header class="inner">
             {% if site.github.is_project_page %}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -14,7 +14,7 @@
   <body>
 
     <!-- HEADER -->
-    <a href="https://rahelv.github.io/software-engineering/" id="home_link">
+    <a href="{{ site.github }}" id="home_link">
         <div id="header_wrap" class="outer">
             <header class="inner">
             {% if site.github.is_project_page %}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -14,7 +14,7 @@
   <body>
 
     <!-- HEADER -->
-    <a href="http://127.0.0.1:4000">
+    <a href="http://127.0.0.1:4000" style="text-decoration: none;">
         <div id="header_wrap" class="outer">
             <header class="inner">
             {% if site.github.is_project_page %}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: "en-US" }}">
+
+  <head>
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,maximum-scale=2">
+    <link rel="stylesheet" type="text/css" media="screen" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+
+{% seo %}
+    {% include head-custom.html %}
+  </head>
+
+  <body>
+
+    <!-- HEADER -->
+    <a href="http://127.0.0.1:4000">
+        <div id="header_wrap" class="outer">
+            <header class="inner">
+            {% if site.github.is_project_page %}
+              <object>
+                  <a id="forkme_banner" href="{{ site.github.repository_url }}">View on GitHub</a>
+              </object>
+            {% endif %}
+
+            <h1 id="project_title">{{ site.title | default: site.github.repository_name }}</h1>
+            <h2 id="project_tagline">{{ site.description | default: site.github.project_tagline }}</h2>
+
+            {% if site.show_downloads %}
+                <section id="downloads">
+                <a class="zip_download_link" href="{{ site.github.zip_url }}">Download this project as a .zip file</a>
+                <a class="tar_download_link" href="{{ site.github.tar_url }}">Download this project as a tar.gz file</a>
+                </section>
+            {% endif %}
+            </header>
+        </div>
+    </a>
+
+    <!-- MAIN CONTENT -->
+    <div id="main_content_wrap" class="outer">
+      <section id="main_content" class="inner">
+        {{ content }}
+      </section>
+    </div>
+
+    <!-- FOOTER  -->
+    <div id="footer_wrap" class="outer">
+      <footer class="inner">
+        {% if site.github.is_project_page %}
+        <p class="copyright">{{ site.title | default: site.github.repository_name }} maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></p>
+        {% endif %}
+        <p>Published with <a href="https://pages.github.com">GitHub Pages</a></p>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -14,7 +14,7 @@
   <body>
 
     <!-- HEADER -->
-    <a href="http://127.0.0.1:4000" style="text-decoration: none;">
+    <a href="http://127.0.0.1:4000" id="home_link">
         <div id="header_wrap" class="outer">
             <header class="inner">
             {% if site.github.is_project_page %}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -14,7 +14,7 @@
   <body>
 
     <!-- HEADER -->
-    <a href="{{ site.github }}" id="home_link">
+    <a href="{{ site.github.url }}" id="home_link">
         <div id="header_wrap" class="outer">
             <header class="inner">
             {% if site.github.is_project_page %}

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -4,3 +4,9 @@
 #footer_wrap {display: none;}
 forkme_banner {display: none;}
 #downloads {display: none;}
+home_link {
+    a:link { text-decoration: none; }
+    a:visited { text-decoration: none; }
+    a:hover { text-decoration: none; }
+    a:active { text-decoration: none; }
+}

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -4,9 +4,8 @@
 #footer_wrap {display: none;}
 forkme_banner {display: none;}
 #downloads {display: none;}
-home_link {
-    a:link { text-decoration: none; }
-    a:visited { text-decoration: none; }
-    a:hover { text-decoration: none; }
-    a:active { text-decoration: none; }
-}
+
+#home_link { text-decoration: none; }
+#home_link:visited { text-decoration: none; }
+#home_link:hover { text-decoration: none; }
+#home_link:active { text-decoration: none; }


### PR DESCRIPTION
While working on the website, I noticed that there is no central way to return to the homepage. This can be a hindrance as you often have to switch between pages to solve the exercises. 

**Changes I made:** 
Overwrite default Layout for the header by adding /_layouts/default.html (copied from [Slate Github Page](https://github.com/pages-themes/slate/tree/master)). 
\- Line 17, 37: Wrap Link to Home Page around header. 
\- Line 21, 23: Put Github link inside <object> tags (workaround because nested links are not allowed) 

Add CSS styles in style.scss so that title and tagline don't present als links. 

To test my implementation, I published it on Github: [Here](https://rahelv.github.io/software-engineering/). 
Everything seems to work fine on Windows (Edge, Chrome & Firefox), and on Safari (on IPad). 

Note: webrick was added to the Gemfile because I wanted to test my implementation locally. Can be removed I think.  